### PR TITLE
WIP: remove missing templates

### DIFF
--- a/layouts/partials/_script/analytics.html
+++ b/layouts/partials/_script/analytics.html
@@ -1,8 +1,6 @@
 <!-- Analytics -->
-{{- if not .Site.IsServer -}}
+{{- if not hugo.IsServer -}}
   {{- if $.Site.Params.mobileTencentAnalytics -}}
     {{ partial "_script/mta.html" .}}
-  {{- else if .Site.GoogleAnalytics -}}
-    {{ template "_internal/google_analytics_async.html" . }}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -58,7 +58,6 @@
   {{- end }}
   {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/spf13/hugo/blob/master/tpl/tplimpl/template_embedded.go#L158 */}}
   {{- template "_internal/opengraph.html" . -}}
-  {{- template "_internal/google_news.html" . -}}
   {{- template "_internal/schema.html" . -}}
   {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
After Hugo version upgrades, some build errors occur. Remove missing internal templates to solve those problems.